### PR TITLE
Code reviews

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,8 +3,11 @@ root = true
 [*]
 end_of_line = lf
 insert_final_newline = true
+indent_style = space
+charset = utf-8
+
+[*.sol]
+indent_size = 4
 
 [*.{js,json,yml}]
-charset = utf-8
-indent_style = space
 indent_size = 2

--- a/contracts/CustomBallot.sol
+++ b/contracts/CustomBallot.sol
@@ -5,7 +5,9 @@ interface IERC20Votes {
     function getPastVotes(address, uint256) external view returns (uint256);
 }
 
+/// @title A Ballot contract integrates ERC20 tokens as voting power.
 contract CustomBallot {
+    /// @notice The event will be notified when a voter voted on a proposal.
     event Voted(
         address indexed voter,
         uint256 indexed proposal,
@@ -13,15 +15,20 @@ contract CustomBallot {
         uint256 proposalVotes
     );
 
+    /// @notice It represents a proposal in the ballot contract.
     struct Proposal {
         bytes32 name;
         uint256 voteCount;
     }
 
+    /// @notice Collection of proposals for voters to choose.
     Proposal[] private _proposals;
+    /// @notice The ERC20 token address that represents voting power.
     IERC20Votes private _voteToken;
+    /// @notice The block number is used as snapshot when the ballot deployed.
     uint256 private _referenceBlock;
 
+    /// @notice Track each voter's spent voting power.
     mapping(address => uint256) private _spentVotePower;
 
     constructor(bytes32[] memory proposalNames, address voteToken) {
@@ -33,14 +40,21 @@ contract CustomBallot {
         }
     }
 
+    /// @notice Get a proposal
+    /// @param index the index of the proposal collection.
     function proposals(uint256 index) external view returns(Proposal memory) {
         return _proposals[index];
     }
 
+    /// @notice Get number of spent voting power of a voter
+    /// @param voter a voter's address
     function spentVotePower(address voter) external view returns(uint256) {
         return _spentVotePower[voter];
     }
 
+    /// @notice Vote on a proposal.
+    /// @param proposal the index of porposal in the proposal collection.
+    /// @param amount the number of voting power to vote on this proposal.
     function vote(uint256 proposal, uint256 amount) external {
         uint256 votingPowerAvailable = votingPower();
         require(votingPowerAvailable >= amount, "Has not enough voting power");
@@ -51,10 +65,12 @@ contract CustomBallot {
         emit Voted(msg.sender, proposal, amount, _proposals[proposal].voteCount);
     }
 
+    /// @notice Get the winner proposal title.
     function winnerName() external view returns (bytes32) {
         return _proposals[winningProposal()].name;
     }
 
+    /// @notice Get the winner proposal index.
     function winningProposal() public view returns (uint256 winningProposal_) {
         uint256 winningVoteCount = 0;
         for (uint256 i = 0; i < _proposals.length; i++) {
@@ -65,6 +81,7 @@ contract CustomBallot {
         }
     }
 
+    /// @notice Get the remaining voting power of the caller.
     function votingPower() public view returns (uint256) {
         return (
             _voteToken.getPastVotes(msg.sender, _referenceBlock) -

--- a/contracts/CustomBallot.sol
+++ b/contracts/CustomBallot.sol
@@ -25,11 +25,12 @@ contract CustomBallot {
     mapping(address => uint256) private _spentVotePower;
 
     constructor(bytes32[] memory proposalNames, address voteToken) {
+        _voteToken = IERC20Votes(voteToken);
+        _referenceBlock = block.number;
+
         for (uint256 i = 0; i < proposalNames.length; i++) {
             _proposals.push(Proposal({name: proposalNames[i], voteCount: 0}));
         }
-        _voteToken = IERC20Votes(voteToken);
-        _referenceBlock = block.number;
     }
 
     function proposals(uint256 index) external view returns(Proposal memory) {
@@ -43,8 +44,10 @@ contract CustomBallot {
     function vote(uint256 proposal, uint256 amount) external {
         uint256 votingPowerAvailable = votingPower();
         require(votingPowerAvailable >= amount, "Has not enough voting power");
+
         _spentVotePower[msg.sender] += amount;
         _proposals[proposal].voteCount += amount;
+
         emit Voted(msg.sender, proposal, amount, _proposals[proposal].voteCount);
     }
 

--- a/contracts/CustomBallot.sol
+++ b/contracts/CustomBallot.sol
@@ -1,61 +1,71 @@
 // SPDX-License-Identifier: MIT
-
 pragma solidity ^0.8.9;
 
 interface IERC20Votes {
-  function getPastVotes(address, uint256) external view returns (uint256);
+    function getPastVotes(address, uint256) external view returns (uint256);
 }
 
 contract CustomBallot {
-  event Voted(
-    address indexed voter,
-    uint256 indexed proposal,
-    uint256 weight,
-    uint256 proposalVotes
-  );
+    event Voted(
+        address indexed voter,
+        uint256 indexed proposal,
+        uint256 weight,
+        uint256 proposalVotes
+    );
 
-  struct Proposal {
-    bytes32 name;
-    uint256 voteCount;
-  }
-
-  mapping (address => uint256) public spentVotePower;
-
-  Proposal[] public proposals;
-  IERC20Votes public voteToken;
-  uint256 public referenceBlock;
-
-  constructor(bytes32[] memory proposalNames, address _voteToken) {
-    for (uint256 i = 0; i < proposalNames.length; i++) {
-      proposals.push(Proposal({name: proposalNames[i], voteCount: 0}));
+    struct Proposal {
+        bytes32 name;
+        uint256 voteCount;
     }
-    voteToken = IERC20Votes(_voteToken);
-    referenceBlock = block.number;
-  }
 
-  function vote(uint256 proposal, uint256 amount) external {
-    uint256 votingPowerAvailable = votingPower();
-    require(votingPowerAvailable >= amount, "Has not enough voting power");
-    spentVotePower[msg.sender] += amount;
-    proposals[proposal].voteCount += amount;
-    emit Voted(msg.sender, proposal, amount, proposals[proposal].voteCount);
-  }
+    Proposal[] private _proposals;
+    IERC20Votes private _voteToken;
+    uint256 private _referenceBlock;
 
-  function winningProposal() public view returns (uint256 winningProposal_) {
-    uint256 winningVoteCount = 0;
-    for (uint256 i = 0; i < proposals.length; i++) {
-      if (proposals[i].voteCount > winningVoteCount) {
-        winningVoteCount = proposals[i].voteCount;
-        winningProposal_ = i;
-      }
+    mapping(address => uint256) private _spentVotePower;
+
+    constructor(bytes32[] memory proposalNames, address voteToken) {
+        for (uint256 i = 0; i < proposalNames.length; i++) {
+            _proposals.push(Proposal({name: proposalNames[i], voteCount: 0}));
+        }
+        _voteToken = IERC20Votes(voteToken);
+        _referenceBlock = block.number;
     }
-  }
 
-  function winnerName() external view returns (bytes32) {
-    return proposals[winningProposal()].name;
-  }
+    function proposals(uint256 index) external view returns(Proposal memory) {
+        return _proposals[index];
+    }
 
-  function votingPower() public view returns (uint256) {
-    return voteToken.getPastVotes(msg.sender, referenceBlock) - spentVotePower[msg.sender];
-  }
+    function spentVotePower(address voter) external view returns(uint256) {
+        return _spentVotePower[voter];
+    }
+
+    function vote(uint256 proposal, uint256 amount) external {
+        uint256 votingPowerAvailable = votingPower();
+        require(votingPowerAvailable >= amount, "Has not enough voting power");
+        _spentVotePower[msg.sender] += amount;
+        _proposals[proposal].voteCount += amount;
+        emit Voted(msg.sender, proposal, amount, _proposals[proposal].voteCount);
+    }
+
+    function winnerName() external view returns (bytes32) {
+        return _proposals[winningProposal()].name;
+    }
+
+    function winningProposal() public view returns (uint256 winningProposal_) {
+        uint256 winningVoteCount = 0;
+        for (uint256 i = 0; i < _proposals.length; i++) {
+            if (_proposals[i].voteCount > winningVoteCount) {
+                winningVoteCount = _proposals[i].voteCount;
+                winningProposal_ = i;
+            }
+        }
+    }
+
+    function votingPower() public view returns (uint256) {
+        return (
+            _voteToken.getPastVotes(msg.sender, _referenceBlock) -
+            _spentVotePower[msg.sender]
+        );
+    }
 }

--- a/contracts/MyToken.sol
+++ b/contracts/MyToken.sol
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: MIT
-
 pragma solidity ^0.8.9;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
@@ -7,29 +6,39 @@ import "@openzeppelin/contracts/access/AccessControl.sol";
 import "@openzeppelin/contracts/token/ERC20/extensions/draft-ERC20Permit.sol";
 import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Votes.sol";
 
-contract MyToken is ERC20, AccessControl, ERC20Permit, ERC20Votes{
-  bytes32 public constant MINTER_ROLE = keccak256("MINTER_ROLE");
+contract MyToken is ERC20, AccessControl, ERC20Permit, ERC20Votes {
+    bytes32 public constant MINTER_ROLE = keccak256("MINTER_ROLE");
 
-  constructor() ERC20("MyToken", "MTK") ERC20Permit("MyToken") {
-    _grantRole(DEFAULT_ADMIN_ROLE, msg.sender);
-    _grantRole(MINTER_ROLE, msg.sender);
-  }
+    constructor() ERC20("MyToken", "MTK") ERC20Permit("MyToken") {
+        _grantRole(DEFAULT_ADMIN_ROLE, msg.sender);
+        _grantRole(MINTER_ROLE, msg.sender);
+    }
 
-  function mint(address to, uint256 amount) public onlyRole(MINTER_ROLE) {
-    _mint(to, amount);
-  }
+    function mint(address to, uint256 amount) public onlyRole(MINTER_ROLE) {
+        _mint(to, amount);
+    }
 
-  // The following functions are overrides required by Solidity.
+    // The following functions are overrides required by Solidity.
 
-  function _afterTokenTransfer(address from, address to, uint256 amount) internal override(ERC20, ERC20Votes) {
-    super._afterTokenTransfer(from, to, amount);
-  }
+    function _afterTokenTransfer(
+        address from,
+        address to,
+        uint256 amount
+    ) internal override(ERC20, ERC20Votes) {
+        super._afterTokenTransfer(from, to, amount);
+    }
 
-  function _mint(address to, uint256 amount) internal override(ERC20, ERC20Votes) {
-    super._mint(to, amount);
-  }
+    function _mint(address to, uint256 amount)
+        internal
+        override(ERC20, ERC20Votes)
+    {
+        super._mint(to, amount);
+    }
 
-  function _burn(address account, uint256 amount) internal override(ERC20, ERC20Votes) {
-    super._burn(account, amount);
-  }
+    function _burn(address account, uint256 amount)
+        internal
+        override(ERC20, ERC20Votes)
+    {
+        super._burn(account, amount);
+    }
 }

--- a/contracts/MyToken.sol
+++ b/contracts/MyToken.sol
@@ -6,7 +6,10 @@ import "@openzeppelin/contracts/access/AccessControl.sol";
 import "@openzeppelin/contracts/token/ERC20/extensions/draft-ERC20Permit.sol";
 import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Votes.sol";
 
+/// @title An ERC20 payment token for purchasing voting power from Ballot contract.
+/// @notice ERC20 + AccessControl + ERC20Votes implementation from OpenZeppelin.
 contract MyToken is ERC20, AccessControl, ERC20Permit, ERC20Votes {
+    /// @notice The deployer will be granted `MINTER_ROLE` to allow minting tokens.
     bytes32 public constant MINTER_ROLE = keccak256("MINTER_ROLE");
 
     constructor() ERC20("MyToken", "MTK") ERC20Permit("MyToken") {
@@ -14,6 +17,9 @@ contract MyToken is ERC20, AccessControl, ERC20Permit, ERC20Votes {
         _grantRole(MINTER_ROLE, msg.sender);
     }
 
+    /// @notice Mint tokens to the recipient address. Only allow to call if the caller has `MINTER_ROLE`.
+    /// @param to The recipient address that will be received tokens.
+    /// @param amount The number of tokens to be minted.
     function mint(address to, uint256 amount) public onlyRole(MINTER_ROLE) {
         _mint(to, amount);
     }


### PR DESCRIPTION
1. Change indentation to 4 spaces
2. Re-order code layout
3. All state variables should be private and they should be prefix by `_`
4. Add NatSpec documentation.

## 1. Change indentation to 4 spaces
Followed https://docs.soliditylang.org/en/v0.8.15/style-guide.html#indentation

## 2. Re-order code layout
Follow these:

https://docs.soliditylang.org/en/v0.8.15/style-guide.html#order-of-functions
https://docs.soliditylang.org/en/v0.8.15/style-guide.html#order-of-layout

## 3. All state variables should be private and they should be prefix by `_`
Followed https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/GUIDELINES.md#solidity-code

The benefit from defining storage variables is public because solidity compiler will define public getters automatically for us, but there are some drawbacks from violent encapsulation. It's hard for the client to know what function signature to call, especially when those variables are in complex data types such as `mapping`. Some of those getters are not necessary by the client, and when we needed, we could define `external` getters ourselves.

## 4. Add NatSpec documentation
Followed https://docs.soliditylang.org/en/v0.8.15/natspec-format.html